### PR TITLE
Validator whitelist

### DIFF
--- a/src/SonicStaking.sol
+++ b/src/SonicStaking.sol
@@ -67,7 +67,7 @@ contract SonicStaking is
     mapping(address user => mapping(uint256 index => uint256 withdrawId)) public userWithdraws;
     mapping(address user => uint256 numWithdraws) public userNumWithdraws;
 
-    mapping(uint256 validatorId => bool whiteListed) public validatorWhiteList;
+    mapping(uint256 validatorId => bool allowed) public validatorAllowList;
 
     /**
      * @dev A reference to the SFC contract
@@ -169,9 +169,9 @@ contract SonicStaking is
     error DonationAmountTooSmall();
     error UnsupportedWithdrawKind();
     error RewardsClaimedTooSmall();
-    error ValidatorNotWhiteListed();
+    error ValidatorNotAllowed();
     error ValidatorIdCannotBeZero();
-    error ValidatorAlreadyWhiteListed();
+    error ValidatorAlreadyAllowed();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {}
@@ -493,8 +493,8 @@ contract SonicStaking is
     function delegate(uint256 validatorId, uint256 amount) external nonReentrant onlyRole(OPERATOR_ROLE) {
         require(amount > 0, DelegateAmountCannotBeZero());
         require(amount <= totalPool, DelegateAmountLargerThanPool());
-        // The operator can only delegate to validators in the white list
-        require(validatorWhiteList[validatorId] == true, ValidatorNotWhiteListed());
+        // The operator can only delegate to validators in the allow list
+        require(validatorAllowList[validatorId], ValidatorNotAllowed());
 
         totalPool -= amount;
         totalDelegated += amount;
@@ -670,25 +670,25 @@ contract SonicStaking is
     }
 
     /**
-     * @notice Add a validator to the white list
-     * @param validatorId the ID of the validator to add to the white list
+     * @notice Add a validator to the allow list
+     * @param validatorId the ID of the validator to add to the allow list
      */
-    function addValidatorToWhiteList(uint256 validatorId) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function addValidatorToAllowList(uint256 validatorId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(validatorId != 0, ValidatorIdCannotBeZero());
-        require(validatorWhiteList[validatorId] == false, ValidatorAlreadyWhiteListed());
+        require(validatorAllowList[validatorId] == false, ValidatorAlreadyAllowed());
 
-        validatorWhiteList[validatorId] = true;
+        validatorAllowList[validatorId] = true;
     }
 
     /**
-     * @notice Remove a validator from the white list
-     * @param validatorId the ID of the validator to remove from the white list
+     * @notice Remove a validator from the allow list
+     * @param validatorId the ID of the validator to remove from the allow list
      */
-    function removeValidatorFromWhiteList(uint256 validatorId) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeValidatorFromAllowList(uint256 validatorId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(validatorId != 0, ValidatorIdCannotBeZero());
-        require(validatorWhiteList[validatorId] == true, ValidatorNotWhiteListed());
+        require(validatorAllowList[validatorId] == true, ValidatorNotAllowed());
 
-        validatorWhiteList[validatorId] = false;
+        validatorAllowList[validatorId] = false;
     }
 
     /**

--- a/test/SonicStakingTestSetup.sol
+++ b/test/SonicStakingTestSetup.sol
@@ -51,8 +51,8 @@ contract SonicStakingTestSetup is Test {
         sonicStaking.renounceRole(sonicStaking.DEFAULT_ADMIN_ROLE(), address(this));
 
         vm.startPrank(SONIC_STAKING_ADMIN);
-        sonicStaking.addValidatorToWhiteList(1);
-        sonicStaking.addValidatorToWhiteList(2);
+        sonicStaking.addValidatorToAllowList(1);
+        sonicStaking.addValidatorToAllowList(2);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Enforce a whitelist of validators as a means to reduce operational error and remove the operators ability to delegate to any validator they choose.

On the fence about this one.